### PR TITLE
Fix/ttl dscp portable sockopt constants

### DIFF
--- a/crates/hdds/src/transport/dscp.rs
+++ b/crates/hdds/src/transport/dscp.rs
@@ -252,23 +252,22 @@ fn set_socket2_tos_raw(socket: &Socket, tos: u8) -> io::Result<()> {
 /// Set TOS on a raw file descriptor.
 #[cfg(unix)]
 fn set_tos_fd(fd: i32, tos: u8) -> io::Result<()> {
-    // IP_TOS = 1 on Linux
-    const IP_TOS: i32 = 1;
-    // IPPROTO_IP = 0
-    const IPPROTO_IP: i32 = 0;
+    // Use libc constants: IP_TOS differs per-OS (Linux=1, macOS/BSD=3)
+    let ip_tos: i32 = libc::IP_TOS;
+    let ipproto_ip: i32 = libc::IPPROTO_IP;
 
     let tos_val = i32::from(tos);
     // SAFETY:
     // - fd is a valid socket descriptor (caller responsibility, obtained from UdpSocket::as_raw_fd())
-    // - IPPROTO_IP (0) and IP_TOS (1) are valid socket option constants
+    // - IPPROTO_IP and IP_TOS are valid socket option constants
     // - tos_val is a stack-allocated i32, properly aligned
     // - size_of::<i32>() correctly represents the option value size
     // - setsockopt only modifies kernel socket state, no memory corruption possible
     let result = unsafe {
         libc::setsockopt(
             fd,
-            IPPROTO_IP,
-            IP_TOS,
+            ipproto_ip,
+            ip_tos,
             &tos_val as *const i32 as *const libc::c_void,
             std::mem::size_of::<i32>() as libc::socklen_t,
         )
@@ -295,23 +294,23 @@ pub fn get_socket_dscp(socket: &UdpSocket) -> Option<DscpClass> {
 /// Get TOS from a raw file descriptor.
 #[cfg(unix)]
 fn get_tos_fd(fd: i32) -> Option<u8> {
-    const IP_TOS: i32 = 1;
-    const IPPROTO_IP: i32 = 0;
+    let ip_tos: i32 = libc::IP_TOS;
+    let ipproto_ip: i32 = libc::IPPROTO_IP;
 
     let mut tos_val: i32 = 0;
     let mut len: libc::socklen_t = std::mem::size_of::<i32>() as libc::socklen_t;
 
     // SAFETY:
     // - fd is a valid socket descriptor (caller responsibility)
-    // - IPPROTO_IP (0) and IP_TOS (1) are valid socket option constants
+    // - IPPROTO_IP and IP_TOS are valid socket option constants
     // - tos_val is a mutable stack-allocated i32, properly aligned
     // - len is initialized to size_of::<i32>() and passed by mutable reference
     // - getsockopt writes at most len bytes to tos_val, which has sufficient space
     let result = unsafe {
         libc::getsockopt(
             fd,
-            IPPROTO_IP,
-            IP_TOS,
+            ipproto_ip,
+            ip_tos,
             &mut tos_val as *mut i32 as *mut libc::c_void,
             &mut len,
         )

--- a/crates/hdds/src/transport/ttl.rs
+++ b/crates/hdds/src/transport/ttl.rs
@@ -173,9 +173,9 @@ pub fn set_socket2_multicast_ttl(socket: &Socket, ttl: u8) -> io::Result<()> {
 /// Set multicast TTL on a raw file descriptor.
 #[cfg(unix)]
 fn set_multicast_ttl_fd(fd: i32, ttl: u8) -> io::Result<()> {
-    // IP_MULTICAST_TTL = 33 on Linux
-    const IP_MULTICAST_TTL: i32 = 33;
-    const IPPROTO_IP: i32 = 0;
+    // Use libc constants: value differs per-OS (Linux=33, macOS/BSD=10)
+    let ip_multicast_ttl: i32 = libc::IP_MULTICAST_TTL;
+    let ipproto_ip: i32 = libc::IPPROTO_IP;
 
     let ttl_val = i32::from(ttl);
     // SAFETY:
@@ -187,8 +187,8 @@ fn set_multicast_ttl_fd(fd: i32, ttl: u8) -> io::Result<()> {
     let result = unsafe {
         libc::setsockopt(
             fd,
-            IPPROTO_IP,
-            IP_MULTICAST_TTL,
+            ipproto_ip,
+            ip_multicast_ttl,
             &ttl_val as *const i32 as *const libc::c_void,
             std::mem::size_of::<i32>() as libc::socklen_t,
         )
@@ -232,9 +232,9 @@ pub fn set_socket2_unicast_ttl(socket: &Socket, ttl: u8) -> io::Result<()> {
 /// Set unicast TTL on a raw file descriptor.
 #[cfg(unix)]
 fn set_unicast_ttl_fd(fd: i32, ttl: u8) -> io::Result<()> {
-    // IP_TTL = 2 on Linux
-    const IP_TTL: i32 = 2;
-    const IPPROTO_IP: i32 = 0;
+    // Use libc constants: value differs per-OS (Linux=2, macOS/BSD=4)
+    let ip_ttl: i32 = libc::IP_TTL;
+    let ipproto_ip: i32 = libc::IPPROTO_IP;
 
     let ttl_val = i32::from(ttl);
     // SAFETY:
@@ -246,8 +246,8 @@ fn set_unicast_ttl_fd(fd: i32, ttl: u8) -> io::Result<()> {
     let result = unsafe {
         libc::setsockopt(
             fd,
-            IPPROTO_IP,
-            IP_TTL,
+            ipproto_ip,
+            ip_ttl,
             &ttl_val as *const i32 as *const libc::c_void,
             std::mem::size_of::<i32>() as libc::socklen_t,
         )
@@ -279,8 +279,8 @@ pub fn get_multicast_ttl(socket: &UdpSocket) -> Option<u8> {
 /// Get multicast TTL from a raw file descriptor.
 #[cfg(unix)]
 fn get_multicast_ttl_fd(fd: i32) -> Option<u8> {
-    const IP_MULTICAST_TTL: i32 = 33;
-    const IPPROTO_IP: i32 = 0;
+    let ip_multicast_ttl: i32 = libc::IP_MULTICAST_TTL;
+    let ipproto_ip: i32 = libc::IPPROTO_IP;
 
     let mut ttl_val: i32 = 0;
     let mut len: libc::socklen_t = std::mem::size_of::<i32>() as libc::socklen_t;
@@ -294,8 +294,8 @@ fn get_multicast_ttl_fd(fd: i32) -> Option<u8> {
     let result = unsafe {
         libc::getsockopt(
             fd,
-            IPPROTO_IP,
-            IP_MULTICAST_TTL,
+            ipproto_ip,
+            ip_multicast_ttl,
             &mut ttl_val as *mut i32 as *mut libc::c_void,
             &mut len,
         )
@@ -319,8 +319,8 @@ pub fn get_unicast_ttl(socket: &UdpSocket) -> Option<u8> {
 /// Get unicast TTL from a raw file descriptor.
 #[cfg(unix)]
 fn get_unicast_ttl_fd(fd: i32) -> Option<u8> {
-    const IP_TTL: i32 = 2;
-    const IPPROTO_IP: i32 = 0;
+    let ip_ttl: i32 = libc::IP_TTL;
+    let ipproto_ip: i32 = libc::IPPROTO_IP;
 
     let mut ttl_val: i32 = 0;
     let mut len: libc::socklen_t = std::mem::size_of::<i32>() as libc::socklen_t;
@@ -334,8 +334,8 @@ fn get_unicast_ttl_fd(fd: i32) -> Option<u8> {
     let result = unsafe {
         libc::getsockopt(
             fd,
-            IPPROTO_IP,
-            IP_TTL,
+            ipproto_ip,
+            ip_ttl,
             &mut ttl_val as *mut i32 as *mut libc::c_void,
             &mut len,
         )


### PR DESCRIPTION
## Description

Two IP-level socket options in `crates/hdds/src/transport/` used hardcoded
Linux numeric constants that are different on macOS/BSD, causing runtime
failure with `IoError(Os { code: 42, kind: Uncategorized, message: "Protocol not available" })`
(ENOPROTOOPT) whenever a Participant tried to configure IP TTL, multicast TTL,
or DSCP on Apple platforms.

Fix: replace the hardcoded numbers with the corresponding `libc::*` constants
so the correct per-platform value is resolved at compile time.

| Constant | Linux (old hardcoded) | macOS/BSD | Now |
|---|---|---|---|
| `IP_MULTICAST_TTL` | 33 | 10 | `libc::IP_MULTICAST_TTL` |
| `IP_TTL`           | 2  | 4  | `libc::IP_TTL` |
| `IP_TOS`           | 1  | 3  | `libc::IP_TOS` |
| `IPPROTO_IP`       | 0  | 0  | `libc::IPPROTO_IP` |

Linux behavior is byte-for-byte unchanged (the `libc::*` values resolve to
the same numeric constants). Windows paths already went through `socket2`
and are untouched.

Files:
- `crates/hdds/src/transport/ttl.rs`
- `crates/hdds/src/transport/dscp.rs`

## Related Issue

N/A — no upstream issue was open. Discovered while building a downstream
`TransportMode::UdpMulticast` publisher on macOS 15 (Apple Silicon).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (existing `// SAFETY:` blocks preserved verbatim)
- [ ] I have made corresponding changes to the documentation (no public API changed)
- [x] My changes generate no new warnings (`cargo clippy` on touched files is clean)
- [ ] I have added tests that prove my fix is effective or that my feature works (existing unit tests already exercise both code paths; they now pass on macOS as well as Linux)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (none required)
- [x] Commits are DCO-signed (`Signed-off-by:` trailer on every commit)

## Testing

Linux (containerized `rust:latest`, aarch64):

```bash
docker run --rm -e CARGO_TARGET_DIR=/tmp/tgt -v "$PWD":/work -w /work rust:latest bash -c "
  cargo fmt --all -- --check &&
  cargo test -p hdds --lib transport::ttl &&
  cargo test -p hdds --lib transport::dscp
"
# Result: 7/7 ttl + 5/5 dscp = 12/12 passed